### PR TITLE
Add support for managing ACLs

### DIFF
--- a/confluentcloud/acl.go
+++ b/confluentcloud/acl.go
@@ -5,25 +5,19 @@ import (
 	"net/url"
 )
 
-type AccessTokenRequest struct{}
-type AccessTokenResponse struct {
-	Token string `json:"token"`
-}
-
 type ACLRequest struct {
-	PatternFilter *PatternFilter `json:"patternFilter"`
-	EntryFilter   *EntryFilter   `json:"entryFilter"`
+	PatternFilter *ListPatternFilter `json:"patternFilter"`
+	EntryFilter   *ListEntryFilter   `json:"entryFilter"`
 }
-type PatternFilter struct {
+type ListPatternFilter struct {
 	ResourceType string `json:"resourceType"`
 	PatternType  string `json:"patternType"`
 }
-type EntryFilter struct {
+type ListEntryFilter struct {
 	Operation      string `json:"operation"`
 	Host           string `json:"host"`
 	PermissionType string `json:"permissionType"`
 }
-
 type ListACLResponse = []ACL
 type ACL struct {
 	Pattern Pattern `json:"pattern"`
@@ -48,12 +42,12 @@ type ACLCreateRequest struct {
 }
 type CreateACLResponse = []ACLCreateRequest
 
-type PatternFilter struct {
+type DeletePatternFilter struct {
 	ResourceType string `json:"resourceType"`
 	Name         string `json:"name"`
 	PatternType  string `json:"patternType"`
 }
-type EntryFilter struct {
+type DeleteEntryFilter struct {
 	Principal      string `json:"principal"`
 	Operation      string `json:"operation"`
 	Host           string `json:"host"`
@@ -61,35 +55,10 @@ type EntryFilter struct {
 }
 type ACLDeleteRequestW = []ACLDeleteRequest
 type ACLDeleteRequest struct {
-	PatternFilter *PatternFilter `json:"patternFilter"`
-	EntryFilter   *EntryFilter   `json:"entryFilter"`
+	PatternFilter *DeletePatternFilter `json:"patternFilter"`
+	EntryFilter   *DeleteEntryFilter   `json:"entryFilter"`
 }
 type DeleteACLResponse = []ACLDeleteRequest
-
-func (c *Client) GetAccessToken() (*string, error) {
-	rel, err := url.Parse("access_tokens")
-	if err != nil {
-		return nil, err
-	}
-
-	u := c.BaseURL.ResolveReference(rel)
-
-	response, err := c.NewRequest().
-		SetBody(AccessTokenRequest{}).
-		SetResult(&AccessTokenResponse{}).
-		SetError(&ErrorResponse{}).
-		Post(u.String())
-
-	if err != nil {
-		return nil, err
-	}
-
-	if response.IsError() {
-		return nil, fmt.Errorf("access_tokens: %s", response.Error().(*ErrorResponse).Error.Message)
-	}
-
-	return &response.Result().(*AccessTokenResponse).Token, nil
-}
 
 func (c *Client) ListACLs(apiEndpoint *url.URL, clusterID string, aclRequest *ACLRequest) ([]ACL, error) {
 	token, err := c.GetKafkaClusterAccessToken()

--- a/confluentcloud/acl.go
+++ b/confluentcloud/acl.go
@@ -1,0 +1,55 @@
+package confluentcloud
+
+import (
+	"fmt"
+	"net/url"
+)
+
+type ACLDeleteRequestW = []ACLDeleteRequest
+type ACLDeleteRequest struct {
+	PatternFilter *PatternFilter `json:"patternFilter"`
+	EntryFilter   *EntryFilter   `json:"entryFilter"`
+}
+type PatternFilter struct {
+	ResourceType string `json:"resourceType"`
+	Name         string `json:"name"`
+	PatternType  string `json:"patternType"`
+}
+type EntryFilter struct {
+	Principal      string `json:"principal"`
+	Operation      string `json:"operation"`
+	Host           string `json:"host"`
+	PermissionType string `json:"permissionType"`
+}
+
+type DeleteACLResponse = []ACLDeleteRequest
+
+func (c *Client) DeleteACLs(apiEndpoint *url.URL, clusterID string, aclDeleteRequestW *ACLDeleteRequestW) (interface{}, error) {
+	token, err := c.GetKafkaClusterAccessToken()
+	if err != nil {
+		return nil, err
+	}
+	cc := NewKafkaClusterClient(apiEndpoint, clusterID, *token)
+
+	rel, err := url.Parse("acls/delete")
+	if err != nil {
+		return nil, err
+	}
+
+	u := cc.BaseURL.ResolveReference(rel)
+
+	response, err := c.NewRequest().
+		SetAuthToken(*token).
+		SetBody(aclDeleteRequestW).
+		SetResult(&DeleteACLResponse{}).
+		Delete(u.String())
+	if err != nil {
+		return nil, err
+	}
+	if response.IsError() {
+		return nil, fmt.Errorf("delete_acls: %s", response.Body())
+	}
+
+	result := response.Result().(*DeleteACLResponse)
+	return *result, nil
+}

--- a/confluentcloud/acl.go
+++ b/confluentcloud/acl.go
@@ -92,7 +92,7 @@ func (c *Client) GetAccessToken() (*string, error) {
 }
 
 func (c *Client) ListACLs(apiEndpoint *url.URL, clusterID string, aclRequest *ACLRequest) ([]ACL, error) {
-	token, err := c.GetAccessToken()
+	token, err := c.GetKafkaClusterAccessToken()
 	if err != nil {
 		return nil, err
 	}

--- a/confluentcloud/acl.go
+++ b/confluentcloud/acl.go
@@ -5,11 +5,25 @@ import (
 	"net/url"
 )
 
-type ACLDeleteRequestW = []ACLDeleteRequest
-type ACLDeleteRequest struct {
-	PatternFilter *PatternFilter `json:"patternFilter"`
-	EntryFilter   *EntryFilter   `json:"entryFilter"`
+type ACLCreateRequestW = []ACLCreateRequest
+type ACLCreateRequest struct {
+	Pattern *Pattern `json:"pattern"`
+	Entry   *Entry   `json:"entry"`
 }
+type Pattern struct {
+	ResourceType string `json:"resourceType"`
+	Name         string `json:"name"`
+	PatternType  string `json:"patternType"`
+}
+type Entry struct {
+	Principal      string `json:"principal"`
+	Operation      string `json:"operation"`
+	Host           string `json:"host"`
+	PermissionType string `json:"permissionType"`
+}
+
+type CreateACLResponse = []ACLCreateRequest
+
 type PatternFilter struct {
 	ResourceType string `json:"resourceType"`
 	Name         string `json:"name"`
@@ -21,8 +35,42 @@ type EntryFilter struct {
 	Host           string `json:"host"`
 	PermissionType string `json:"permissionType"`
 }
-
+type ACLDeleteRequestW = []ACLDeleteRequest
+type ACLDeleteRequest struct {
+	PatternFilter *PatternFilter `json:"patternFilter"`
+	EntryFilter   *EntryFilter   `json:"entryFilter"`
+}
 type DeleteACLResponse = []ACLDeleteRequest
+
+func (c *Client) CreateACLs(apiEndpoint *url.URL, clusterID string, aclCreateRequestW *ACLCreateRequestW) (interface{}, error) {
+	token, err := c.GetKafkaClusterAccessToken()
+	if err != nil {
+		return nil, err
+	}
+	cc := NewKafkaClusterClient(apiEndpoint, clusterID, *token)
+
+	rel, err := url.Parse("acls")
+	if err != nil {
+		return nil, err
+	}
+
+	u := cc.BaseURL.ResolveReference(rel)
+
+	response, err := c.NewRequest().
+		SetAuthToken(*token).
+		SetBody(aclCreateRequestW).
+		SetResult(&CreateACLResponse{}).
+		Post(u.String())
+	if err != nil {
+		return nil, err
+	}
+	if response.IsError() {
+		return nil, fmt.Errorf("create_acls: %s", response.Body())
+	}
+
+	result := response.Result().(*CreateACLResponse)
+	return *result, nil
+}
 
 func (c *Client) DeleteACLs(apiEndpoint *url.URL, clusterID string, aclDeleteRequestW *ACLDeleteRequestW) (interface{}, error) {
 	token, err := c.GetKafkaClusterAccessToken()

--- a/confluentcloud/acl.go
+++ b/confluentcloud/acl.go
@@ -5,10 +5,29 @@ import (
 	"net/url"
 )
 
-type ACLCreateRequestW = []ACLCreateRequest
-type ACLCreateRequest struct {
-	Pattern *Pattern `json:"pattern"`
-	Entry   *Entry   `json:"entry"`
+type AccessTokenRequest struct{}
+type AccessTokenResponse struct {
+	Token string `json:"token"`
+}
+
+type ACLRequest struct {
+	PatternFilter *PatternFilter `json:"patternFilter"`
+	EntryFilter   *EntryFilter   `json:"entryFilter"`
+}
+type PatternFilter struct {
+	ResourceType string `json:"resourceType"`
+	PatternType  string `json:"patternType"`
+}
+type EntryFilter struct {
+	Operation      string `json:"operation"`
+	Host           string `json:"host"`
+	PermissionType string `json:"permissionType"`
+}
+
+type ListACLResponse = []ACL
+type ACL struct {
+	Pattern Pattern `json:"pattern"`
+	Entry   Entry   `json:"entry"`
 }
 type Pattern struct {
 	ResourceType string `json:"resourceType"`
@@ -22,6 +41,11 @@ type Entry struct {
 	PermissionType string `json:"permissionType"`
 }
 
+type ACLCreateRequestW = []ACLCreateRequest
+type ACLCreateRequest struct {
+	Pattern *Pattern `json:"pattern"`
+	Entry   *Entry   `json:"entry"`
+}
 type CreateACLResponse = []ACLCreateRequest
 
 type PatternFilter struct {
@@ -41,6 +65,62 @@ type ACLDeleteRequest struct {
 	EntryFilter   *EntryFilter   `json:"entryFilter"`
 }
 type DeleteACLResponse = []ACLDeleteRequest
+
+func (c *Client) GetAccessToken() (*string, error) {
+	rel, err := url.Parse("access_tokens")
+	if err != nil {
+		return nil, err
+	}
+
+	u := c.BaseURL.ResolveReference(rel)
+
+	response, err := c.NewRequest().
+		SetBody(AccessTokenRequest{}).
+		SetResult(&AccessTokenResponse{}).
+		SetError(&ErrorResponse{}).
+		Post(u.String())
+
+	if err != nil {
+		return nil, err
+	}
+
+	if response.IsError() {
+		return nil, fmt.Errorf("access_tokens: %s", response.Error().(*ErrorResponse).Error.Message)
+	}
+
+	return &response.Result().(*AccessTokenResponse).Token, nil
+}
+
+func (c *Client) ListACLs(apiEndpoint *url.URL, clusterID string, aclRequest *ACLRequest) ([]ACL, error) {
+	token, err := c.GetAccessToken()
+	if err != nil {
+		return nil, err
+	}
+	cc := NewKafkaClusterClient(apiEndpoint, clusterID, *token)
+
+	// cannot use url.Parse due to colon being interpreted as scheme
+	suffix := url.URL{
+		Path: "acls:search",
+	}
+	u := cc.BaseURL.ResolveReference(&suffix)
+	response, err := cc.NewKafkaClusterRequest().
+		SetAuthToken(*token).
+		SetBody(aclRequest).
+		SetResult(&ListACLResponse{}).
+		Post(u.String())
+
+	if err != nil {
+		return nil, err
+	}
+
+	// response is raw, cannot parse from JSON
+	if response.IsError() {
+		return nil, fmt.Errorf("list_acls: %s", response.Body())
+	}
+
+	result := response.Result().(*ListACLResponse)
+	return *result, nil
+}
 
 func (c *Client) CreateACLs(apiEndpoint *url.URL, clusterID string, aclCreateRequestW *ACLCreateRequestW) (interface{}, error) {
 	token, err := c.GetKafkaClusterAccessToken()

--- a/confluentcloud/cluster_endpoint.go
+++ b/confluentcloud/cluster_endpoint.go
@@ -1,0 +1,72 @@
+package confluentcloud
+
+import (
+	"fmt"
+	"github.com/go-resty/resty/v2"
+	"net/url"
+)
+
+const (
+	baseURLSuffix = "2.0/kafka/"
+)
+
+type KafkaClusterClient struct {
+	KafkaApiEndpoint *url.URL
+	BaseURLSuffix    string
+	BaseURL          *url.URL
+	client           *resty.Client
+	token            string
+}
+
+type AccessTokenRequest struct{}
+type AccessTokenResponse struct {
+	Token string `json:"token"`
+}
+
+// NewKafkaClusterClient constructs a new client to connect to the relevant Kafka Confluent Cluster in order to query ACLs
+//
+// kafkaApiEndpoint and clusterID can be retrieved from the ID and APIEndpoint fields within Cluster
+func NewKafkaClusterClient(kafkaApiEndpoint *url.URL, clusterID string, token string) *KafkaClusterClient {
+	_baseURL := fmt.Sprintf("%s/%s%s/", kafkaApiEndpoint, baseURLSuffix, clusterID)
+	baseURL, _ := url.Parse(_baseURL)
+
+	client := resty.New()
+	client.SetDebug(true)
+	c := &KafkaClusterClient{KafkaApiEndpoint: kafkaApiEndpoint, BaseURL: baseURL, BaseURLSuffix: baseURLSuffix}
+	c.client = client
+	c.token = token
+
+	return c
+}
+
+func (c *KafkaClusterClient) NewKafkaClusterRequest() *resty.Request {
+	return c.client.R()
+}
+
+// GetKafkaClusterAccessToken retrieves the token required to authenticate the NewKafkaClusterClient
+//
+// This hits the standard confluent.cloud endpoint
+func (c *Client) GetKafkaClusterAccessToken() (*string, error) {
+	rel, err := url.Parse("access_tokens")
+	if err != nil {
+		return nil, err
+	}
+
+	u := c.BaseURL.ResolveReference(rel)
+
+	response, err := c.NewRequest().
+		SetBody(AccessTokenRequest{}).
+		SetResult(&AccessTokenResponse{}).
+		SetError(&ErrorResponse{}).
+		Post(u.String())
+
+	if err != nil {
+		return nil, err
+	}
+
+	if response.IsError() {
+		return nil, fmt.Errorf("access_tokens: %s", response.Error().(*ErrorResponse).Error.Message)
+	}
+
+	return &response.Result().(*AccessTokenResponse).Token, nil
+}


### PR DESCRIPTION
Hey everyone, I noticed that you don't currently have support for interacting with ACLs so here's something :) 

This is all reverse engineered from the calls ccloud makes itself, though confluent themselves don't seem to offer this functionality, even in the early access v2 API.

It's relatively straightforward, you need an access token from the main endpoint, which you then pass to the cluster endpoint that you want to manage so I've made a new client to handle this, smooth sailing after that.

I've tested this locally with some sample scripts that I can share if people want them/update the readme, otherwise please let me know if you have any other questions or feedback, I'm new to go so if I've structured/called things weirdly call me out on it, I've tried to follow established patterns where possible.